### PR TITLE
#17 fix - loadScript call moved in ngAfterViewInit

### DIFF
--- a/projects/email-editor/src/lib/email-editor.component.ts
+++ b/projects/email-editor/src/lib/email-editor.component.ts
@@ -44,11 +44,10 @@ export class EmailEditorComponent implements OnInit, AfterViewInit {
     this.editorId = `editor-${++lastEditorId}`;
    }
 
-  ngOnInit() {
-    loadScript(this.loadEditor.bind(this));
-  }
+  ngOnInit() {}
 
   ngAfterViewInit() {
+    loadScript(this.loadEditor.bind(this));
   }
 
   protected loadEditor() {


### PR DESCRIPTION
fix for issue #17 @umairsiddique @adeelraza 
When we use this component into the popup, then the only first-time editor is getting applied. But if we close the popup and open it again, then id is not reflected in the component. That's why the error is getting (mentioned in issue #17 ). After moving `loadScript` call moved in `ngAfterViewInit` it is working fine.