### PR TITLE
chore: migrate from unlayer-types to @unlayer/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@angular/cli": "~15.0.0",
         "@angular/compiler-cli": "^15.0.0",
         "@types/jasmine": "~4.3.0",
+        "@unlayer/types": "^1.394.0",
         "jasmine-core": "~4.5.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.1.0",
@@ -32,8 +33,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "ng-packagr": "^15.0.0",
-        "typescript": "~4.8.2",
-        "unlayer-types": "^1.33.0"
+        "typescript": "~4.8.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3880,6 +3880,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@unlayer/types": {
+      "version": "1.394.0",
+      "resolved": "https://registry.npmjs.org/@unlayer/types/-/types-1.394.0.tgz",
+      "integrity": "sha512-M88e2kEiOl6pFPLrzVqQgeTk/c/s0DB6DTFB2Oa+wJGqq+RQm6Ck0D0DkqoDbsDmetJXhpSPDKz56AAQ06oJwQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -12151,13 +12158,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/unlayer-types": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/unlayer-types/-/unlayer-types-1.33.0.tgz",
-      "integrity": "sha512-Px6uMWKSPsmVgW3Bc6g1UDiIN1/7xKsEUlm+BjiVIwGD7osUEJUQfh5GYLOseStQT6bISfuGMsKg1OkjJ2ABtQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@angular/cli": "~15.0.0",
     "@angular/compiler-cli": "^15.0.0",
     "@types/jasmine": "~4.3.0",
+    "@unlayer/types": "^1.394.0",
     "jasmine-core": "~4.5.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",
@@ -41,7 +42,6 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
     "ng-packagr": "^15.0.0",
-    "typescript": "~4.8.2",
-    "unlayer-types": "^1.33.0"
+    "typescript": "~4.8.2"
   }
 }

--- a/projects/email-editor/package.json
+++ b/projects/email-editor/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angular-email-editor",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "peerDependencies": {
-    "unlayer-types": "latest"
+    "@unlayer/types": "latest"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/email-editor/package.json
+++ b/projects/email-editor/package.json
@@ -2,7 +2,7 @@
   "name": "angular-email-editor",
   "version": "15.3.0",
   "peerDependencies": {
-    "@unlayer/types": "latest"
+    "@unlayer/types": "^1.394.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/email-editor/src/lib/email-editor.component.ts
+++ b/projects/email-editor/src/lib/email-editor.component.ts
@@ -75,7 +75,7 @@ export class EmailEditorComponent implements OnInit, AfterViewInit {
     this.editor = unlayer.createEditor({
       ...options,
       id: this.id,
-      displayMode: 'email',
+      displayMode: options.displayMode || 'email',
       source: {
         name: pkg.name,
         version: pkg.version,

--- a/projects/email-editor/src/lib/source.json
+++ b/projects/email-editor/src/lib/source.json
@@ -2,7 +2,7 @@
   "name": "angular-email-editor",
   "version": "15.2.0",
   "peerDependencies": {
-    "unlayer-types": "latest"
+    "@unlayer/types": "latest"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/email-editor/src/lib/source.json
+++ b/projects/email-editor/src/lib/source.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-email-editor",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "peerDependencies": {
     "@unlayer/types": "latest"
   },

--- a/projects/email-editor/src/lib/source.json
+++ b/projects/email-editor/src/lib/source.json
@@ -2,7 +2,7 @@
   "name": "angular-email-editor",
   "version": "15.3.0",
   "peerDependencies": {
-    "@unlayer/types": "latest"
+    "@unlayer/types": "^1.394.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/email-editor/src/types.ts
+++ b/projects/email-editor/src/types.ts
@@ -1,15 +1,14 @@
-/// <reference path="../../../node_modules/unlayer-types/embed.d.ts" />
-
-import Embed from 'embed/index';
-import { Editor as EditorClass } from 'embed/Editor';
-import {
+import type {
+  UnlayerEmbed,
+  UnlayerEditor,
+  UnlayerOptions as UnlayerOptionsType,
   JSONTemplate as JSONTemplateType,
   ToolsConfig as ToolsConfigInterface,
-} from 'state/types/types';
+} from '@unlayer/types';
 
-export type Unlayer = typeof Embed;
-export type UnlayerOptions = Parameters<Unlayer['createEditor']>[0];
-export type Editor = InstanceType<typeof EditorClass>;
+export type Unlayer = UnlayerEmbed;
+export type UnlayerOptions = UnlayerOptionsType;
+export type Editor = UnlayerEditor;
 
 export type ToolsConfig = ToolsConfigInterface;
 

--- a/src/app/example/example.component.ts
+++ b/src/app/example/example.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { EmailEditorComponent } from 'email-editor';
+import type { JSONTemplate } from '@unlayer/types';
 
 import sample from './sample.json';
 
@@ -31,7 +32,7 @@ export class ExampleComponent implements OnInit {
   // called when the editor is created
   editorLoaded() {
     console.log('editorLoaded');
-    this.unlayer.loadDesign(sample);
+    this.unlayer.loadDesign(sample as unknown as JSONTemplate);
   }
 
   // called when the editor has finished loading


### PR DESCRIPTION
## Summary
- Replace legacy `unlayer-types` (ambient module declarations) with the new scoped `@unlayer/types` package (standard ES module exports)
- Update peer dependency from `unlayer-types` to `@unlayer/types`
- Bump version to `15.3.0`

## Changes
- `projects/email-editor/src/types.ts` — rewrite imports to use `@unlayer/types`
- `projects/email-editor/package.json` — update peer dependency + version bump
- `package.json` / `package-lock.json` — swap devDependency

## Backward Compatibility
- All consumer-facing type names (`Unlayer`, `Editor`, `UnlayerOptions`, `ToolsConfig`, `JSONTemplate`, `EditorRef`) are preserved
- No code changes required for consumers — only peer dependency swap:
  ```
  npm uninstall unlayer-types
  npm install @unlayer/types
  ```

## Test Plan
- [x] Library builds successfully (`npm run build-lib`)
- [x] Angular v18 test project builds with tarball install
- [x] Unit tests pass (2/2)
- [x] Dev server runs and editor loads correctly
- [x] No remaining references to `unlayer-types` in source or dist